### PR TITLE
Change the way data is written to the temporary ts segment.

### DIFF
--- a/src/logic/convert-hls-to-mp4.ts
+++ b/src/logic/convert-hls-to-mp4.ts
@@ -1,0 +1,119 @@
+import wasmURL from "@ffmpeg/core/wasm?url";
+import coreURL from "@ffmpeg/core?url";
+import { FFmpeg } from "@ffmpeg/ffmpeg";
+import { parse, stringify } from "hls-parser";
+import pLimit from "p-limit";
+import sha256 from "sha256";
+import type { RetryOptions } from "ts-retry";
+import { retryAsync } from "ts-retry";
+
+/**
+ * Converts an HLS (HTTP Live Streaming) manifest to an MP4 file.
+ *
+ * @param {string} m3u8Content - The content of the HLS manifest file.
+ * @param {(url: string) => Promise<Uint8Array>} fetchFile - A function to fetch a file from a URL.
+ * @param {(current: number, total: number, timeCurrent: number, timeDuration: number) => void} onProgress - A callback function to report the progress of the conversion.
+ * @param {number} [concurrency=20] - The number of concurrent downloads.
+ * @param {RetryOptions} [retryOptions] - Options for retrying failed downloads.
+ * @return {Promise<FileData>} The MP4 file data.
+ */
+export async function convertHlsToMP4(
+  m3u8Content: string,
+  fetchFile: (url: string) => Promise<Uint8Array>,
+  onProgress: (
+    current: number,
+    total: number,
+    timeCurrent: number,
+    timeDuration: number
+  ) => void,
+  concurrency = 20,
+  retryOptions?: RetryOptions
+) {
+  const ffmpeg = new FFmpeg();
+
+  const hash = sha256(m3u8Content);
+  const manifest = parse(m3u8Content);
+
+  if (!("segments" in manifest))
+    throw new Error("Can't support master playlist");
+
+  if (import.meta.env.DEV)
+    ffmpeg.on("log", ({ message }) => {
+      console.log(`[@ffmpeg/ffmpeg]: ${message}`);
+    });
+
+  if (import.meta.env.DEV)
+    ffmpeg.on("progress", ({ progress, time }) => {
+      console.log(`${progress * 100} % (transcoded time: ${time / 1000000} s)`);
+    });
+
+  await ffmpeg.load({
+    coreURL,
+    wasmURL,
+  });
+
+  const limit = pLimit(concurrency);
+
+  const timeDuration = manifest.segments.reduce(
+    (prev, cur) => cur.duration + prev,
+    0
+  );
+  // Download all the TS segments
+  let downloaded = 0;
+  let timeCurrent = 0;
+  await Promise.all(
+    manifest.segments.map((segment, i) =>
+      limit(() =>
+        retryAsync<void>(async () => {
+          const path = `${hash}-${i}.ts`;
+          let response = await fetchFile(segment.uri);
+          response =
+            indexOfIEND(response) !== 1
+              ? response.slice(indexOfIEND(response))
+              : response;
+          await ffmpeg.writeFile(path, response);
+          segment.uri = path;
+          downloaded++;
+          timeCurrent += segment.duration;
+          onProgress(
+            downloaded,
+            manifest.segments.length,
+            timeCurrent,
+            timeDuration
+          );
+        }, retryOptions)
+      )
+    )
+  );
+  await ffmpeg.writeFile(`${hash}-media.m3u8`, stringify(manifest));
+
+  await ffmpeg.exec([
+    "-i",
+    `${hash}-media.m3u8`,
+    ..."-acodec copy -vcodec copy".split(" "),
+    `${hash}-output.mp4`,
+  ]);
+
+  // Retrieve the output file
+  const mp4Data = await ffmpeg.readFile(`${hash}-output.mp4`);
+
+  return mp4Data;
+}
+const IEND_IMAGE = Uint8Array.from([
+  0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+function indexOfIEND(buf: Uint8Array<ArrayBufferLike>): number {
+  for (let i = 0; i < buf.length - IEND_IMAGE.length; i++) {
+    let found = true;
+    for (let j = 0; j < IEND_IMAGE.length; j++) {
+      if (buf[i + j] !== IEND_IMAGE[j]) {
+        found = false;
+        break;
+      }
+    }
+    if (found) {
+      return i + IEND_IMAGE.length;
+    }
+  }
+  return -1;
+}


### PR DESCRIPTION
### **User description**
If I write the original data fetched from fetchFile it won't read the ts segment to combine into mp4, so I split the image and ts segment. Then write the ts segment and it works.
<h1>Before</h1>
<img width="891" height="132" alt="Screenshot 2025-09-09 130131" src="https://github.com/user-attachments/assets/6b97e2a4-7b2e-496b-a5ec-94782c08ad03" />
<h1>After</h1>
<img width="895" height="378" alt="Screenshot 2025-09-09 125938" src="https://github.com/user-attachments/assets/2e4b8498-b238-44ae-a7e6-7aaaa0ae4e54" />


___

### **PR Type**
Enhancement


___

### **Description**
- Add HLS to MP4 conversion functionality with FFmpeg

- Implement PNG/image data separation from TS segments

- Support concurrent downloads with retry mechanism

- Add progress tracking for conversion process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HLS Manifest"] --> B["Parse M3U8"]
  B --> C["Download TS Segments"]
  C --> D["Separate Image Data"]
  D --> E["Write Clean TS Files"]
  E --> F["FFmpeg Conversion"]
  F --> G["MP4 Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>convert-hls-to-mp4.ts</strong><dd><code>Complete HLS to MP4 converter implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/logic/convert-hls-to-mp4.ts

<ul><li>Add complete HLS to MP4 conversion function with FFmpeg integration<br> <li> Implement <code>indexOfIEND</code> function to detect and separate PNG image data <br>from TS segments<br> <li> Support concurrent downloads with configurable retry options and <br>progress callbacks<br> <li> Handle manifest parsing, segment processing, and final MP4 output <br>generation</ul>


</details>


  </td>
  <td><a href="https://github.com/anime-vsub/app/pull/116/files#diff-50489146bae6c79fcc7b5f2eecbe5422fcc2d89c0cc1153a3ae72b489d021b0e">+119/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

